### PR TITLE
Used global setup to reduce test time

### DIFF
--- a/test/integration/integration_motion.mjs
+++ b/test/integration/integration_motion.mjs
@@ -15,14 +15,49 @@ import sinonChai from 'sinon-chai';
 chai.use(sinonChai);
 const expect = chai.expect;
 
+let vm = null;
+let sprite = null;
+let target = null;
+
+let sprite2 = null;
+let target2 = null;
+
+before( async () => {  
+    vm = new VirtualMachine();
+
+    sprite = new Sprite(null, vm.runtime);
+    target = new RenderedTarget(sprite, vm.runtime);
+    target.id = 'target1';
+    vm.runtime.addTarget(target);
+
+    sprite2 = new Sprite(null, vm.runtime);
+    target2 = new RenderedTarget(sprite2, vm.runtime);
+    target2.id = 'target2';
+    sprite2.name = 'target2';
+
+    vm.runtime.addTarget(target2);
+
+});
+
+const resetVm = () => {
+    vm.runtime.targets.map((target) => {
+        target.x = 0;
+        target.y = 0;
+        target.direction = 90;
+
+        return target;
+    });
+}
+
+beforeEach(async () => {
+    resetVm();
+});
+
+
 describe('Pyatch VM Linker & Worker Integration', () => {
     describe('Motion Blocks', () => {
         it('Move', async () => {
-            const vm = new VirtualMachine();
-            const sprite = new Sprite(null, vm.runtime);
-            const target = new RenderedTarget(sprite, vm.runtime);
-            target.id = 'target1';
-            vm.runtime.addTarget(target);
+            
 
             const targetAndCode = {
                 target1: ['move(10)'],
@@ -36,11 +71,7 @@ describe('Pyatch VM Linker & Worker Integration', () => {
         });
         
         it('Go To XY', async () => {
-            const vm = new VirtualMachine();
-            const sprite = new Sprite(null, vm.runtime);
-            const target = new RenderedTarget(sprite, vm.runtime);
-            target.id = 'target1';
-            vm.runtime.addTarget(target);
+            
 
             const targetAndCode = {
                 target1: ['goToXY(10, 5)'],
@@ -54,23 +85,14 @@ describe('Pyatch VM Linker & Worker Integration', () => {
         });
 
         it('Go To', async () => {
-            const vm = new VirtualMachine();
-            const sprite = new Sprite(null, vm.runtime);
-            const target = new RenderedTarget(sprite, vm.runtime);
-            target.id = 'target1';
-            vm.runtime.addTarget(target);
+            
 
             const targetAndCode = {
                 target1: ['goTo("target2")'],
             };
 
-            const sprite2 = new Sprite(null, vm.runtime);
-            const target2 = new RenderedTarget(sprite2, vm.runtime);
-            target2.id = 'target2';
-            sprite2.name = 'target2';
             target2.x = 10;
             target2.y = 5;
-            vm.runtime.addTarget(target2);
 
             const result = await vm.run(targetAndCode);
 
@@ -80,11 +102,7 @@ describe('Pyatch VM Linker & Worker Integration', () => {
         });
 
         it('Turn Right', async () => {
-            const vm = new VirtualMachine();
-            const sprite = new Sprite(null, vm.runtime);
-            const target = new RenderedTarget(sprite, vm.runtime);
-            target.id = 'target1';
-            vm.runtime.addTarget(target);
+            
 
             const targetAndCode = {
                 target1: ['turnRight(90)'],
@@ -97,11 +115,7 @@ describe('Pyatch VM Linker & Worker Integration', () => {
         });
 
         it('Turn Left', async () => {
-            const vm = new VirtualMachine();
-            const sprite = new Sprite(null, vm.runtime);
-            const target = new RenderedTarget(sprite, vm.runtime);
-            target.id = 'target1';
-            vm.runtime.addTarget(target);
+            
 
             const targetAndCode = {
                 target1: ['turnLeft(90)'],
@@ -114,11 +128,7 @@ describe('Pyatch VM Linker & Worker Integration', () => {
         });
 
         it('Point In Direction', async () => {
-            const vm = new VirtualMachine();
-            const sprite = new Sprite(null, vm.runtime);
-            const target = new RenderedTarget(sprite, vm.runtime);
-            target.id = 'target1';
-            vm.runtime.addTarget(target);
+            
 
             const targetAndCode = {
                 target1: ['pointInDirection(90)'],
@@ -132,23 +142,14 @@ describe('Pyatch VM Linker & Worker Integration', () => {
 
 
         it('pointTowards', async () => {
-            const vm = new VirtualMachine();
-            const sprite = new Sprite(null, vm.runtime);
-            const target = new RenderedTarget(sprite, vm.runtime);
-            target.id = 'target1';
-            vm.runtime.addTarget(target);
+            
 
             const targetAndCode = {
                 target1: ['pointTowards("target2")'],
             };
 
-            const sprite2 = new Sprite(null, vm.runtime);
-            const target2 = new RenderedTarget(sprite2, vm.runtime);
-            target2.id = 'target2';
-            sprite2.name = 'target2';
             target2.x = 5;
             target2.y = 5;
-            vm.runtime.addTarget(target2);
 
             const result = await vm.run(targetAndCode);
 
@@ -157,11 +158,7 @@ describe('Pyatch VM Linker & Worker Integration', () => {
         });
 
         it('Glide', async () => {
-            const vm = new VirtualMachine();
-            const sprite = new Sprite(null, vm.runtime);
-            const target = new RenderedTarget(sprite, vm.runtime);
-            target.id = 'target1';
-            vm.runtime.addTarget(target);
+            
 
             const targetAndCode = {
                 target1: ['glide(10, 5, 1)'],
@@ -175,22 +172,14 @@ describe('Pyatch VM Linker & Worker Integration', () => {
         });
 
         it('Glide To', async () => {
-            const vm = new VirtualMachine();
-            const sprite = new Sprite(null, vm.runtime);
-            const target = new RenderedTarget(sprite, vm.runtime);
-            target.id = 'target1';
-            vm.runtime.addTarget(target);
+            
 
             const targetAndCode = {
                 target1: ['glideTo("target2", 1)'],
             };
 
-            const sprite2 = new Sprite(null, vm.runtime);
-            const target2 = new RenderedTarget(sprite2, vm.runtime);
-            target2.id = 'target2';
             target2.x = 10;
             target2.y = 5;
-            vm.runtime.addTarget(target2);
 
             const result = await vm.run(targetAndCode);
 
@@ -200,11 +189,7 @@ describe('Pyatch VM Linker & Worker Integration', () => {
         });
 
         it('If On Edge Bounce', async () => {
-            const vm = new VirtualMachine();
-            const sprite = new Sprite(null, vm.runtime);
-            const target = new RenderedTarget(sprite, vm.runtime);
-            target.id = 'target1';
-            vm.runtime.addTarget(target);
+            
 
             const targetAndCode = {
                 target1: ['ifOnEdgeBounce()'],
@@ -217,11 +202,7 @@ describe('Pyatch VM Linker & Worker Integration', () => {
         });
 
         it('Set Rotation Style', async () => {
-            const vm = new VirtualMachine();
-            const sprite = new Sprite(null, vm.runtime);
-            const target = new RenderedTarget(sprite, vm.runtime);
-            target.id = 'target1';
-            vm.runtime.addTarget(target);
+            
 
             const targetAndCode = {
                 target1: ['setRotationStyle("leftRight")'],
@@ -234,11 +215,7 @@ describe('Pyatch VM Linker & Worker Integration', () => {
         });
 
         it('Change X', async () => {
-            const vm = new VirtualMachine();
-            const sprite = new Sprite(null, vm.runtime);
-            const target = new RenderedTarget(sprite, vm.runtime);
-            target.id = 'target1';
-            vm.runtime.addTarget(target);
+            
 
             const oldX = target.x;
             const dx = 10;
@@ -256,11 +233,7 @@ describe('Pyatch VM Linker & Worker Integration', () => {
         });
 
         it('Change Y', async () => {
-            const vm = new VirtualMachine();
-            const sprite = new Sprite(null, vm.runtime);
-            const target = new RenderedTarget(sprite, vm.runtime);
-            target.id = 'target1';
-            vm.runtime.addTarget(target);
+            
 
             const oldX = target.x;
             const oldY = target.y;
@@ -278,11 +251,7 @@ describe('Pyatch VM Linker & Worker Integration', () => {
         });
 
         it('Set X', async () => {
-            const vm = new VirtualMachine();
-            const sprite = new Sprite(null, vm.runtime);
-            const target = new RenderedTarget(sprite, vm.runtime);
-            target.id = 'target1';
-            vm.runtime.addTarget(target);
+            
 
             const eX = 10;
             const oldY = target.y;
@@ -299,11 +268,7 @@ describe('Pyatch VM Linker & Worker Integration', () => {
         });
 
         it('Set Y', async () => {
-            const vm = new VirtualMachine();
-            const sprite = new Sprite(null, vm.runtime);
-            const target = new RenderedTarget(sprite, vm.runtime);
-            target.id = 'target1';
-            vm.runtime.addTarget(target);
+            
 
             const oldX = target.x;
             const eY = 10;

--- a/test/worker/worker.mjs
+++ b/test/worker/worker.mjs
@@ -29,396 +29,311 @@ const blockOPTestCallback = (spy) => {
 	}
 }
 
-describe('Pyatch Worker Async Run', () => {
-	describe('Motion Primitive Functions', () => {
-		it('Move', async () => {
+let spy = null;
+let pyatchWorker = null;
+
+before( async () => {  
+	spy = sinon.spy();
+	pyatchWorker = new PyatchWorker(PATH_TO_WORKER, blockOPTestCallback(spy));	
 
-			const spy = sinon.spy();
-			const pyatchWorker = new PyatchWorker(PATH_TO_WORKER, blockOPTestCallback(spy));
+	await pyatchWorker.loadPyodide();
+});
+
+beforeEach(async () => {
+	spy.resetHistory();
+});
+
+after( async () => {
+	pyatchWorker.terminate();
+});
+
+describe('Pyatch Worker Fucntionality', () => {
+	describe('Async Run', () => {
+		describe('Motion Primitive Functions', () => {
+			it('Move', async () => {
+				const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-move.py'), 'utf8');
+				const targetArr = ['target1'];	
 
-			const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-move.py'), 'utf8');
-			const targetArr = ['target1'];	
+				const runResult = await pyatchWorker.run(pythonCode, targetArr);
+				expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
 
-			const loadResult = await pyatchWorker.loadPyodide();
-			expect(loadResult).to.equal(WorkerMessages.ToVM.PyodideLoaded);
+				expect(spy).to.be.calledOnce;
+		
+				let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
+				expect(lastCallData.id).to.equal('BlockOP')
+				expect(lastCallData.targetID).to.equal(targetArr[0])
+				expect(lastCallData.opCode).to.equal('motion_movesteps')
+				expect(lastCallData.args).to.eql({ STEPS: 10 })
+				expect(lastCallData.token).to.be.a('string')
 
-			const runResult = await pyatchWorker.run(pythonCode, targetArr);
-			expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
+				
+			});
 
-			expect(spy).to.be.calledOnce;
-	
-			let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
-			expect(lastCallData.id).to.equal('BlockOP')
-			expect(lastCallData.targetID).to.equal(targetArr[0])
-			expect(lastCallData.opCode).to.equal('motion_movesteps')
-			expect(lastCallData.args).to.eql({ STEPS: 10 })
-			expect(lastCallData.token).to.be.a('string')
+			it('Go To XY', async () => {
+				const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-gotoxy.py'), 'utf8');
+				const targetArr = ['target1'];	
 
-			pyatchWorker.terminate();
-		});
+				const runResult = await pyatchWorker.run(pythonCode, targetArr);
+				expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
 
-		it('Go To XY', async () => {
+				expect(spy).to.be.calledOnce;
 
-			const spy = sinon.spy();
-			const pyatchWorker = new PyatchWorker(PATH_TO_WORKER, blockOPTestCallback(spy));
+				let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
+				expect(lastCallData.id).to.equal('BlockOP')
+				expect(lastCallData.targetID).to.equal(targetArr[0])
+				expect(lastCallData.opCode).to.equal('motion_gotoxy')
+				expect(lastCallData.args).to.eql({ X: 10, Y: 5 })
+				expect(lastCallData.token).to.be.a('string')
 
-			const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-gotoxy.py'), 'utf8');
-			const targetArr = ['target1'];	
+				
+			});
 
-			const loadResult = await pyatchWorker.loadPyodide();
-			expect(loadResult).to.equal(WorkerMessages.ToVM.PyodideLoaded);
+			it('Go To', async () => {
+				const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-goto.py'), 'utf8');
+				const targetArr = ['target1'];	
 
-			const runResult = await pyatchWorker.run(pythonCode, targetArr);
-			expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
+				const runResult = await pyatchWorker.run(pythonCode, targetArr);
+				expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
 
-			expect(spy).to.be.calledOnce;
+				expect(spy).to.be.calledOnce;
 
-			let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
-			expect(lastCallData.id).to.equal('BlockOP')
-			expect(lastCallData.targetID).to.equal(targetArr[0])
-			expect(lastCallData.opCode).to.equal('motion_gotoxy')
-			expect(lastCallData.args).to.eql({ X: 10, Y: 5 })
-			expect(lastCallData.token).to.be.a('string')
+				let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
+				expect(lastCallData.id).to.equal('BlockOP')
+				expect(lastCallData.targetID).to.equal(targetArr[0])
+				expect(lastCallData.opCode).to.equal('motion_goto')
+				expect(lastCallData.args).to.eql({ TO: 'target1' })
+				expect(lastCallData.token).to.be.a('string')
 
-			pyatchWorker.terminate();
-		});
+				
+			});
 
-		it('Go To', async () => {
+			it('Turn Right', async () => {
+				const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-turnright.py'), 'utf8');
+				const targetArr = ['target1'];	
 
-			const spy = sinon.spy();
-			const pyatchWorker = new PyatchWorker(PATH_TO_WORKER, blockOPTestCallback(spy));
+				const runResult = await pyatchWorker.run(pythonCode, targetArr);
+				expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
 
-			const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-goto.py'), 'utf8');
-			const targetArr = ['target1'];	
+				expect(spy).to.be.calledOnce;
 
-			const loadResult = await pyatchWorker.loadPyodide();
-			expect(loadResult).to.equal(WorkerMessages.ToVM.PyodideLoaded);
+				let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
+				expect(lastCallData.id).to.equal('BlockOP')
+				expect(lastCallData.targetID).to.equal(targetArr[0])
+				expect(lastCallData.opCode).to.equal('motion_turnright')
+				expect(lastCallData.args).to.eql({ DEGREES: 90 })
+				expect(lastCallData.token).to.be.a('string')
 
-			const runResult = await pyatchWorker.run(pythonCode, targetArr);
-			expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
+				
+			});
 
-			expect(spy).to.be.calledOnce;
+			it('Turn Left', async () => {
+				const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-turnleft.py'), 'utf8');
+				const targetArr = ['target1'];	
 
-			let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
-			expect(lastCallData.id).to.equal('BlockOP')
-			expect(lastCallData.targetID).to.equal(targetArr[0])
-			expect(lastCallData.opCode).to.equal('motion_goto')
-			expect(lastCallData.args).to.eql({ TO: 'target1' })
-			expect(lastCallData.token).to.be.a('string')
+				const runResult = await pyatchWorker.run(pythonCode, targetArr);
+				expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
 
-			pyatchWorker.terminate();
-		});
+				expect(spy).to.be.calledOnce;
 
-		it('Turn Right', async () => {
+				let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
+				expect(lastCallData.id).to.equal('BlockOP')
+				expect(lastCallData.targetID).to.equal(targetArr[0])
+				expect(lastCallData.opCode).to.equal('motion_turnleft')
+				expect(lastCallData.args).to.eql({ DEGREES: 90 })
+				expect(lastCallData.token).to.be.a('string')
 
-			const spy = sinon.spy();
-			const pyatchWorker = new PyatchWorker(PATH_TO_WORKER, blockOPTestCallback(spy));
+				
+			});
 
-			const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-turnright.py'), 'utf8');
-			const targetArr = ['target1'];	
+			it('Point In Direction', async () => {
+				const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-pointindirection.py'), 'utf8');
+				const targetArr = ['target1'];	
 
-			const loadResult = await pyatchWorker.loadPyodide();
-			expect(loadResult).to.equal(WorkerMessages.ToVM.PyodideLoaded);
+				const runResult = await pyatchWorker.run(pythonCode, targetArr);
+				expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
 
-			const runResult = await pyatchWorker.run(pythonCode, targetArr);
-			expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
+				expect(spy).to.be.calledOnce;
 
-			expect(spy).to.be.calledOnce;
+				let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
+				expect(lastCallData.id).to.equal('BlockOP')
+				expect(lastCallData.targetID).to.equal(targetArr[0])
+				expect(lastCallData.opCode).to.equal('motion_pointindirection')
+				expect(lastCallData.args).to.eql({ DIRECTION: 90 })
+				expect(lastCallData.token).to.be.a('string')
 
-			let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
-			expect(lastCallData.id).to.equal('BlockOP')
-			expect(lastCallData.targetID).to.equal(targetArr[0])
-			expect(lastCallData.opCode).to.equal('motion_turnright')
-			expect(lastCallData.args).to.eql({ DEGREES: 90 })
-			expect(lastCallData.token).to.be.a('string')
+				
+			});
 
-			pyatchWorker.terminate();
-		});
+			it('Point Towards', async () => {
+				const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-pointtowards.py'), 'utf8');
+				const targetArr = ['target1'];	
 
-		it('Turn Left', async () => {
+				const runResult = await pyatchWorker.run(pythonCode, targetArr);
+				expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
 
-			const spy = sinon.spy();
-			const pyatchWorker = new PyatchWorker(PATH_TO_WORKER, blockOPTestCallback(spy));
+				expect(spy).to.be.calledOnce;
 
-			const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-turnleft.py'), 'utf8');
-			const targetArr = ['target1'];	
+				let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
+				expect(lastCallData.id).to.equal('BlockOP')
+				expect(lastCallData.targetID).to.equal(targetArr[0])
+				expect(lastCallData.opCode).to.equal('motion_pointtowards')
+				expect(lastCallData.args).to.eql({ TOWARDS: 'target1' })
+				expect(lastCallData.token).to.be.a('string')
 
-			const loadResult = await pyatchWorker.loadPyodide();
-			expect(loadResult).to.equal(WorkerMessages.ToVM.PyodideLoaded);
+				
+			});
 
-			const runResult = await pyatchWorker.run(pythonCode, targetArr);
-			expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
+			it('Glide', async () => {
+				const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-glide.py'), 'utf8');
+				const targetArr = ['target1'];	
 
-			expect(spy).to.be.calledOnce;
+				const runResult = await pyatchWorker.run(pythonCode, targetArr);
+				expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
 
-			let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
-			expect(lastCallData.id).to.equal('BlockOP')
-			expect(lastCallData.targetID).to.equal(targetArr[0])
-			expect(lastCallData.opCode).to.equal('motion_turnleft')
-			expect(lastCallData.args).to.eql({ DEGREES: 90 })
-			expect(lastCallData.token).to.be.a('string')
+				expect(spy).to.be.calledOnce;
 
-			pyatchWorker.terminate();
-		});
+				let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
+				expect(lastCallData.id).to.equal('BlockOP')
+				expect(lastCallData.targetID).to.equal(targetArr[0])
+				expect(lastCallData.opCode).to.equal('motion_glidesecstoxy')
+				expect(lastCallData.args).to.eql({ SECS: 1, X: 10, Y:5 })
+				expect(lastCallData.token).to.be.a('string')
 
-		it('Point In Direction', async () => {
+				
+			});
 
-			const spy = sinon.spy();
-			const pyatchWorker = new PyatchWorker(PATH_TO_WORKER, blockOPTestCallback(spy));
+			it('Glide To', async () => {
+				const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-glideto.py'), 'utf8');
+				const targetArr = ['target1'];	
 
-			const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-pointindirection.py'), 'utf8');
-			const targetArr = ['target1'];	
+				const runResult = await pyatchWorker.run(pythonCode, targetArr);
+				expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
 
-			const loadResult = await pyatchWorker.loadPyodide();
-			expect(loadResult).to.equal(WorkerMessages.ToVM.PyodideLoaded);
+				expect(spy).to.be.calledOnce;
 
-			const runResult = await pyatchWorker.run(pythonCode, targetArr);
-			expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
+				let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
+				expect(lastCallData.id).to.equal('BlockOP')
+				expect(lastCallData.targetID).to.equal(targetArr[0])
+				expect(lastCallData.opCode).to.equal('motion_glideto')
+				expect(lastCallData.args).to.eql({ SECS: 1, TO: 'target1' })
+				expect(lastCallData.token).to.be.a('string')
 
-			expect(spy).to.be.calledOnce;
+				
+			});
 
-			let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
-			expect(lastCallData.id).to.equal('BlockOP')
-			expect(lastCallData.targetID).to.equal(targetArr[0])
-			expect(lastCallData.opCode).to.equal('motion_pointindirection')
-			expect(lastCallData.args).to.eql({ DIRECTION: 90 })
-			expect(lastCallData.token).to.be.a('string')
+			it('If On Edge Bounce', async () => {
+				const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-ifonedgebounce.py'), 'utf8');
+				const targetArr = ['target1'];	
 
-			pyatchWorker.terminate();
-		});
+				const runResult = await pyatchWorker.run(pythonCode, targetArr);
+				expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
 
-		it('Point Towards', async () => {
+				expect(spy).to.be.calledOnce;
 
-			const spy = sinon.spy();
-			const pyatchWorker = new PyatchWorker(PATH_TO_WORKER, blockOPTestCallback(spy));
+				let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
+				expect(lastCallData.id).to.equal('BlockOP')
+				expect(lastCallData.targetID).to.equal(targetArr[0])
+				expect(lastCallData.opCode).to.equal('motion_ifonedgebounce')
+				expect(lastCallData.args).to.eql({})
+				expect(lastCallData.token).to.be.a('string')
 
-			const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-pointtowards.py'), 'utf8');
-			const targetArr = ['target1'];	
+				
+			});
 
-			const loadResult = await pyatchWorker.loadPyodide();
-			expect(loadResult).to.equal(WorkerMessages.ToVM.PyodideLoaded);
+			it('Set Rotation Style', async () => {
+				const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-setrotationstyle.py'), 'utf8');
+				const targetArr = ['target1'];	
 
-			const runResult = await pyatchWorker.run(pythonCode, targetArr);
-			expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
+				const runResult = await pyatchWorker.run(pythonCode, targetArr);
+				expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
 
-			expect(spy).to.be.calledOnce;
+				expect(spy).to.be.calledOnce;
 
-			let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
-			expect(lastCallData.id).to.equal('BlockOP')
-			expect(lastCallData.targetID).to.equal(targetArr[0])
-			expect(lastCallData.opCode).to.equal('motion_pointtowards')
-			expect(lastCallData.args).to.eql({ TOWARDS: 'target1' })
-			expect(lastCallData.token).to.be.a('string')
+				let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
+				expect(lastCallData.id).to.equal('BlockOP')
+				expect(lastCallData.targetID).to.equal(targetArr[0])
+				expect(lastCallData.opCode).to.equal('motion_setrotationstyle')
+				expect(lastCallData.args).to.eql({ STYLE: 'free' })
+				expect(lastCallData.token).to.be.a('string')
 
-			pyatchWorker.terminate();
-		});
+				
+			});
 
-		it('Glide', async () => {
+			it('Change X', async () => {
+				const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-changex.py'), 'utf8');
+				const targetArr = ['target1'];	
 
-			const spy = sinon.spy();
-			const pyatchWorker = new PyatchWorker(PATH_TO_WORKER, blockOPTestCallback(spy));
+				const runResult = await pyatchWorker.run(pythonCode, targetArr);
+				expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
 
-			const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-glide.py'), 'utf8');
-			const targetArr = ['target1'];	
+				expect(spy).to.be.calledOnce;
 
-			const loadResult = await pyatchWorker.loadPyodide();
-			expect(loadResult).to.equal(WorkerMessages.ToVM.PyodideLoaded);
+				let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
+				expect(lastCallData.id).to.equal('BlockOP')
+				expect(lastCallData.targetID).to.equal(targetArr[0])
+				expect(lastCallData.opCode).to.equal('motion_changexby')
+				expect(lastCallData.args).to.eql({ DX: 10 })
+				expect(lastCallData.token).to.be.a('string')
 
-			const runResult = await pyatchWorker.run(pythonCode, targetArr);
-			expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
+				
+			});
 
-			expect(spy).to.be.calledOnce;
+			it('Set X', async () => {
+				const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-setx.py'), 'utf8');
+				const targetArr = ['target1'];	
 
-			let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
-			expect(lastCallData.id).to.equal('BlockOP')
-			expect(lastCallData.targetID).to.equal(targetArr[0])
-			expect(lastCallData.opCode).to.equal('motion_glidesecstoxy')
-			expect(lastCallData.args).to.eql({ SECS: 1, X: 10, Y:5 })
-			expect(lastCallData.token).to.be.a('string')
+				const runResult = await pyatchWorker.run(pythonCode, targetArr);
+				expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
 
-			pyatchWorker.terminate();
-		});
+				expect(spy).to.be.calledOnce;
 
-		it('Glide To', async () => {
+				let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
+				expect(lastCallData.id).to.equal('BlockOP')
+				expect(lastCallData.targetID).to.equal(targetArr[0])
+				expect(lastCallData.opCode).to.equal('motion_setx')
+				expect(lastCallData.args).to.eql({ X: 10 })
+				expect(lastCallData.token).to.be.a('string')
 
-			const spy = sinon.spy();
-			const pyatchWorker = new PyatchWorker(PATH_TO_WORKER, blockOPTestCallback(spy));
+				
+			});
 
-			const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-glideto.py'), 'utf8');
-			const targetArr = ['target1'];	
+			it('Change Y', async () => {
+				const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-changey.py'), 'utf8');
+				const targetArr = ['target1'];	
 
-			const loadResult = await pyatchWorker.loadPyodide();
-			expect(loadResult).to.equal(WorkerMessages.ToVM.PyodideLoaded);
+				const runResult = await pyatchWorker.run(pythonCode, targetArr);
+				expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
 
-			const runResult = await pyatchWorker.run(pythonCode, targetArr);
-			expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
+				expect(spy).to.be.calledOnce;
 
-			expect(spy).to.be.calledOnce;
+				let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
+				expect(lastCallData.id).to.equal('BlockOP')
+				expect(lastCallData.targetID).to.equal(targetArr[0])
+				expect(lastCallData.opCode).to.equal('motion_changeyby')
+				expect(lastCallData.args).to.eql({ DY: 10 })
+				expect(lastCallData.token).to.be.a('string')
 
-			let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
-			expect(lastCallData.id).to.equal('BlockOP')
-			expect(lastCallData.targetID).to.equal(targetArr[0])
-			expect(lastCallData.opCode).to.equal('motion_glideto')
-			expect(lastCallData.args).to.eql({ SECS: 1, TO: 'target1' })
-			expect(lastCallData.token).to.be.a('string')
+				
+			});
 
-			pyatchWorker.terminate();
-		});
+			it('Set Y', async () => {
+				const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-sety.py'), 'utf8');
+				const targetArr = ['target1'];	
 
-		it('If On Edge Bounce', async () => {
+				const runResult = await pyatchWorker.run(pythonCode, targetArr);
+				expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
 
-			const spy = sinon.spy();
-			const pyatchWorker = new PyatchWorker(PATH_TO_WORKER, blockOPTestCallback(spy));
+				expect(spy).to.be.calledOnce;
 
-			const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-ifonedgebounce.py'), 'utf8');
-			const targetArr = ['target1'];	
+				let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
+				expect(lastCallData.id).to.equal('BlockOP')
+				expect(lastCallData.targetID).to.equal(targetArr[0])
+				expect(lastCallData.opCode).to.equal('motion_sety')
+				expect(lastCallData.args).to.eql({ Y: 10 })
+				expect(lastCallData.token).to.be.a('string')
 
-			const loadResult = await pyatchWorker.loadPyodide();
-			expect(loadResult).to.equal(WorkerMessages.ToVM.PyodideLoaded);
-
-			const runResult = await pyatchWorker.run(pythonCode, targetArr);
-			expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
-
-			expect(spy).to.be.calledOnce;
-
-			let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
-			expect(lastCallData.id).to.equal('BlockOP')
-			expect(lastCallData.targetID).to.equal(targetArr[0])
-			expect(lastCallData.opCode).to.equal('motion_ifonedgebounce')
-			expect(lastCallData.args).to.eql({})
-			expect(lastCallData.token).to.be.a('string')
-
-			pyatchWorker.terminate();
-		});
-
-		it('Set Rotation Style', async () => {
-
-			const spy = sinon.spy();
-			const pyatchWorker = new PyatchWorker(PATH_TO_WORKER, blockOPTestCallback(spy));
-
-			const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-setrotationstyle.py'), 'utf8');
-			const targetArr = ['target1'];	
-
-			const loadResult = await pyatchWorker.loadPyodide();
-			expect(loadResult).to.equal(WorkerMessages.ToVM.PyodideLoaded);
-
-			const runResult = await pyatchWorker.run(pythonCode, targetArr);
-			expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
-
-			expect(spy).to.be.calledOnce;
-
-			let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
-			expect(lastCallData.id).to.equal('BlockOP')
-			expect(lastCallData.targetID).to.equal(targetArr[0])
-			expect(lastCallData.opCode).to.equal('motion_setrotationstyle')
-			expect(lastCallData.args).to.eql({ STYLE: 'free' })
-			expect(lastCallData.token).to.be.a('string')
-
-			pyatchWorker.terminate();
-		});
-
-		it('Change X', async () => {
-
-			const spy = sinon.spy();
-			const pyatchWorker = new PyatchWorker(PATH_TO_WORKER, blockOPTestCallback(spy));
-
-			const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-changex.py'), 'utf8');
-			const targetArr = ['target1'];	
-
-			const loadResult = await pyatchWorker.loadPyodide();
-			expect(loadResult).to.equal(WorkerMessages.ToVM.PyodideLoaded);
-
-			const runResult = await pyatchWorker.run(pythonCode, targetArr);
-			expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
-
-			expect(spy).to.be.calledOnce;
-
-			let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
-			expect(lastCallData.id).to.equal('BlockOP')
-			expect(lastCallData.targetID).to.equal(targetArr[0])
-			expect(lastCallData.opCode).to.equal('motion_changexby')
-			expect(lastCallData.args).to.eql({ DX: 10 })
-			expect(lastCallData.token).to.be.a('string')
-
-			pyatchWorker.terminate();
-		});
-
-		it('Set X', async () => {
-
-			const spy = sinon.spy();
-			const pyatchWorker = new PyatchWorker(PATH_TO_WORKER, blockOPTestCallback(spy));
-
-			const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-setx.py'), 'utf8');
-			const targetArr = ['target1'];	
-
-			const loadResult = await pyatchWorker.loadPyodide();
-			expect(loadResult).to.equal(WorkerMessages.ToVM.PyodideLoaded);
-
-			const runResult = await pyatchWorker.run(pythonCode, targetArr);
-			expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
-
-			expect(spy).to.be.calledOnce;
-
-			let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
-			expect(lastCallData.id).to.equal('BlockOP')
-			expect(lastCallData.targetID).to.equal(targetArr[0])
-			expect(lastCallData.opCode).to.equal('motion_setx')
-			expect(lastCallData.args).to.eql({ X: 10 })
-			expect(lastCallData.token).to.be.a('string')
-
-			pyatchWorker.terminate();
-		});
-
-		it('Change Y', async () => {
-
-			const spy = sinon.spy();
-			const pyatchWorker = new PyatchWorker(PATH_TO_WORKER, blockOPTestCallback(spy));
-
-			const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-changey.py'), 'utf8');
-			const targetArr = ['target1'];	
-
-			const loadResult = await pyatchWorker.loadPyodide();
-			expect(loadResult).to.equal(WorkerMessages.ToVM.PyodideLoaded);
-
-			const runResult = await pyatchWorker.run(pythonCode, targetArr);
-			expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
-
-			expect(spy).to.be.calledOnce;
-
-			let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
-			expect(lastCallData.id).to.equal('BlockOP')
-			expect(lastCallData.targetID).to.equal(targetArr[0])
-			expect(lastCallData.opCode).to.equal('motion_changeyby')
-			expect(lastCallData.args).to.eql({ DY: 10 })
-			expect(lastCallData.token).to.be.a('string')
-
-			pyatchWorker.terminate();
-		});
-
-		it('Set Y', async () => {
-
-			const spy = sinon.spy();
-			const pyatchWorker = new PyatchWorker(PATH_TO_WORKER, blockOPTestCallback(spy));
-
-			const pythonCode = fs.readFileSync(path.join(__dirname, './python', 'single-target-sety.py'), 'utf8');
-			const targetArr = ['target1'];	
-
-			const loadResult = await pyatchWorker.loadPyodide();
-			expect(loadResult).to.equal(WorkerMessages.ToVM.PyodideLoaded);
-
-			const runResult = await pyatchWorker.run(pythonCode, targetArr);
-			expect(runResult).to.equal(WorkerMessages.ToVM.PythonFinished);
-
-			expect(spy).to.be.calledOnce;
-
-			let lastCallData = spy.getCalls().slice(-1)[0].firstArg;
-			expect(lastCallData.id).to.equal('BlockOP')
-			expect(lastCallData.targetID).to.equal(targetArr[0])
-			expect(lastCallData.opCode).to.equal('motion_sety')
-			expect(lastCallData.args).to.eql({ Y: 10 })
-			expect(lastCallData.token).to.be.a('string')
-
-			pyatchWorker.terminate();
+				
+			});
 		});
 	});
 });


### PR DESCRIPTION
### Proposed Changes

Used mocha global setup hooks to initialize long loading objects once at the beginning of testing

### Reason for Changes

Tests were very slow to run.
