### PR TITLE
Elliotbroe/bxc 30 multiline while bug

### DIFF
--- a/src/linker/pyatch-linker.mjs
+++ b/src/linker/pyatch-linker.mjs
@@ -89,7 +89,7 @@ class PyatchLinker {
             codeString += this.generateTargetHeader(targetId);
 
             for (let i = 0; i < targetCode.length; i++) {
-                const code = targetCode[i].replace('\n', '\n' + linkConstants.python_tab_char);
+                const code = targetCode[i].replaceAll('\n', '\n' + linkConstants.python_tab_char);
                 const header = this.generateAsyncFuncHeader(targetId, i.toString());
                 const registerPrimsCode = this.registerProxyPrims(targetCode[i]);
                 codeString += header + registerPrimsCode + linkConstants.python_tab_char + code + '\n\n';

--- a/src/worker/pyodide-web.worker.mjs
+++ b/src/worker/pyodide-web.worker.mjs
@@ -107,7 +107,6 @@ function _run(pythonScript,  targets) {
 
   let target_func_arr = []
 
-  // TODO: Need to loop through each async function in the global scope and run them concurrently
   for(let global of self.pyodide.globals) {
     if (global.includes('target')) {
       target_func_arr.push(self.pyodide.globals.get(global))

--- a/test/linker/expected/while-loop-expected.py
+++ b/test/linker/expected/while-loop-expected.py
@@ -1,0 +1,7 @@
+## -- target1 -- ##
+
+async def target1_0(vm_proxy):
+    move = vm_proxy.move
+    while True:
+        move(10)
+        move(10)

--- a/test/linker/expected/while-loop-expected.py
+++ b/test/linker/expected/while-loop-expected.py
@@ -5,3 +5,4 @@ async def target1_0(vm_proxy):
     while True:
         move(10)
         move(10)
+

--- a/test/linker/input/while-loop.py
+++ b/test/linker/input/while-loop.py
@@ -1,3 +1,3 @@
 while True:
-  move(10)
-  move(10)
+    move(10)
+    move(10)

--- a/test/linker/input/while-loop.py
+++ b/test/linker/input/while-loop.py
@@ -1,0 +1,3 @@
+while True:
+  move(10)
+  move(10)

--- a/test/linker/linker.mjs
+++ b/test/linker/linker.mjs
@@ -62,5 +62,21 @@ describe("Pyatch File Linker", function() {
         expect(targetArr).to.deep.equal(['target1']);
         expect(code).to.equal(expected);
     });
+
+    it("1 target, 2 lines of code nested, 1 threads", function() {
+
+        let inputFile = path.join(__dirname, "./", "input", "while-loop.py");
+        let inputStr = fs.readFileSync(inputFile, "utf8", function(err, data) {return data});
+        const targetCode = {
+            target1: [inputStr]
+        }
+        let file = path.join(__dirname, "./", "expected", "while-loop-expected.py");
+        let expected = fs.readFileSync(file, "utf8", function(err, data) {return data});
+
+        const [targetArr, code] = linker.generatePython(targetCode)
+
+        expect(targetArr).to.deep.equal(['target1']);
+        expect(code).to.equal(expected);
+    });
   });
 });


### PR DESCRIPTION
### Resolves

Patch linker while loop test error. Instead of adding a tab to just the first newline, adds a tab to every newline in the python code.

### Test Coverage

Changing while-loop-expected.py to end with two newlines in line with the other expected.py files.
Changing input/while-loop.py to have a tab size of 4 to match other python files.
