### PR TITLE
Linker handles python await syntax implicitly

### DIFF
--- a/src/worker/prim-proxy.js
+++ b/src/worker/prim-proxy.js
@@ -71,32 +71,32 @@ class PrimProxy {
         return Object.keys(PrimProxy.opcodeMap);
     }
 
-    move(steps) {
-        this.post(PrimProxy.opcodeMap.move, { STEPS: steps });
+    async move(steps) {
+        await this.post(PrimProxy.opcodeMap.move, { STEPS: steps });
     }
 
-    goToXY(x, y) {
-        this.post(PrimProxy.opcodeMap.goToXY, { X: x, Y: y });
+    async goToXY(x, y) {
+        await this.post(PrimProxy.opcodeMap.goToXY, { X: x, Y: y });
     }
 
-    goTo(targetName) {
-        this.post(PrimProxy.opcodeMap.goTo, { TO: targetName });
+    async goTo(targetName) {
+        await this.post(PrimProxy.opcodeMap.goTo, { TO: targetName });
     }
 
-    turnRight(degrees) {
-        this.post(PrimProxy.opcodeMap.turnRight, { DEGREES: degrees });
+    async turnRight(degrees) {
+        await this.post(PrimProxy.opcodeMap.turnRight, { DEGREES: degrees });
     }
 
-    turnLeft(degrees) {
-        this.post(PrimProxy.opcodeMap.turnLeft, { DEGREES: degrees });
+    async turnLeft(degrees) {
+        await this.post(PrimProxy.opcodeMap.turnLeft, { DEGREES: degrees });
     }
 
-    pointInDirection(degrees) {
-        this.post(PrimProxy.opcodeMap.pointInDirection, { DIRECTION: degrees });
+    async pointInDirection(degrees) {
+        await this.post(PrimProxy.opcodeMap.pointInDirection, { DIRECTION: degrees });
     }
 
-    pointTowards(targetName) {
-        this.post(PrimProxy.opcodeMap.pointTowards, { TOWARDS: targetName });
+    async pointTowards(targetName) {
+        await this.post(PrimProxy.opcodeMap.pointTowards, { TOWARDS: targetName });
     }
 
     async glide(seconds, x, y) {
@@ -110,28 +110,28 @@ class PrimProxy {
         });
     }
 
-    ifOnEdgeBounce() {
-        this.post(PrimProxy.opcodeMap.ifOnEdgeBounce, {});
+    async ifOnEdgeBounce() {
+        await this.post(PrimProxy.opcodeMap.ifOnEdgeBounce, {});
     }
 
-    setRotationStyle(style) {
-        this.post(PrimProxy.opcodeMap.setRotationStyle, { STYLE: style });
+    async setRotationStyle(style) {
+        await this.post(PrimProxy.opcodeMap.setRotationStyle, { STYLE: style });
     }
 
-    changeX(deltaX) {
-        this.post(PrimProxy.opcodeMap.changeX, { DX: deltaX });
+    async changeX(deltaX) {
+        await this.post(PrimProxy.opcodeMap.changeX, { DX: deltaX });
     }
 
-    setX(x) {
-        this.post(PrimProxy.opcodeMap.setX, { X: x });
+    async setX(x) {
+        await this.post(PrimProxy.opcodeMap.setX, { X: x });
     }
 
-    changeY(deltaY) {
-        this.post(PrimProxy.opcodeMap.changeY, { DY: deltaY });
+    async changeY(deltaY) {
+        await this.post(PrimProxy.opcodeMap.changeY, { DY: deltaY });
     }
 
-    setY(y) {
-        this.post(PrimProxy.opcodeMap.setY, { Y: y });
+    async setY(y) {
+        await this.post(PrimProxy.opcodeMap.setY, { Y: y });
     }
 
     async getX() {
@@ -149,148 +149,148 @@ class PrimProxy {
         return direction;
     }
 
-    say(message) {
-        this.post(PrimProxy.opcodeMap.say, { MESSAGE: message });
+    async say(message) {
+        await this.post(PrimProxy.opcodeMap.say, { MESSAGE: message });
     }
 
-    sayFor(message, secs) {
-        this.post(PrimProxy.opcodeMap.sayFor, { MESSAGE: message, SECS: secs });
+    async sayFor(message, secs) {
+        await this.post(PrimProxy.opcodeMap.sayFor, { MESSAGE: message, SECS: secs });
     }
 
-    think(message) {
-        this.post(PrimProxy.opcodeMap.think, { MESSAGE: message });
+    async think(message) {
+        await this.post(PrimProxy.opcodeMap.think, { MESSAGE: message });
     }
 
-    thinkFor(message, secs) {
-        this.post(PrimProxy.opcodeMap.thinkFor, {
+    async thinkFor(message, secs) {
+        await this.post(PrimProxy.opcodeMap.thinkFor, {
             MESSAGE: message,
             SECS: secs,
         });
     }
 
-    show() {
-        this.post(PrimProxy.opcodeMap.show, {});
+    async show() {
+        await this.post(PrimProxy.opcodeMap.show, {});
     }
 
-    hide() {
-        this.post(PrimProxy.opcodeMap.hide, {});
+    async hide() {
+        await this.post(PrimProxy.opcodeMap.hide, {});
     }
 
-    setCostumeTo(costume) {
-        this.post(PrimProxy.opcodeMap.setCostumeTo, { COSTUME: costume });
+    async setCostumeTo(costume) {
+        await this.post(PrimProxy.opcodeMap.setCostumeTo, { COSTUME: costume });
     }
 
-    setBackdropTo(backdrop) {
-        this.post(PrimProxy.opcodeMap.setBackdropTo, { BACKDROP: backdrop });
+    async setBackdropTo(backdrop) {
+        await this.post(PrimProxy.opcodeMap.setBackdropTo, { BACKDROP: backdrop });
     }
 
-    setBackdropToAndWait(backdrop) {
-        this.post(PrimProxy.opcodeMap.setBackdropToAndWait, {
+    async setBackdropToAndWait(backdrop) {
+        await this.post(PrimProxy.opcodeMap.setBackdropToAndWait, {
             BACKDROP: backdrop,
         });
     }
 
-    nextCostume() {
-        this.post(PrimProxy.opcodeMap.nextCostume, {});
+    async nextCostume() {
+        await this.post(PrimProxy.opcodeMap.nextCostume, {});
     }
 
-    nextBackdrop() {
-        this.post(PrimProxy.opcodeMap.nextBackdrop, {});
+    async nextBackdrop() {
+        await this.post(PrimProxy.opcodeMap.nextBackdrop, {});
     }
 
-    changeGraphicEffectBy(effect, change) {
-        this.post(PrimProxy.opcodeMap.changeGraphicEffectBy, {
+    async changeGraphicEffectBy(effect, change) {
+        await this.post(PrimProxy.opcodeMap.changeGraphicEffectBy, {
             EFFECT: effect,
             CHANGE: change,
         });
     }
 
-    setGraphicEffectTo(effect, value) {
-        this.post(PrimProxy.opcodeMap.setGraphicEffectTo, {
+    async setGraphicEffectTo(effect, value) {
+        await this.post(PrimProxy.opcodeMap.setGraphicEffectTo, {
             EFFECT: effect,
             VALUE: value,
         });
     }
 
-    clearGraphicEffects() {
-        this.post(PrimProxy.opcodeMap.clearGraphicEffects, {});
+    async clearGraphicEffects() {
+        await this.post(PrimProxy.opcodeMap.clearGraphicEffects, {});
     }
 
-    changeSizeBy(change) {
-        this.post(PrimProxy.opcodeMap.changeSizeBy, { CHANGE: change });
+    async changeSizeBy(change) {
+        await this.post(PrimProxy.opcodeMap.changeSizeBy, { CHANGE: change });
     }
 
-    setSizeTo(size) {
-        this.post(PrimProxy.opcodeMap.setSizeTo, { SIZE: size });
+    async setSizeTo(size) {
+        await this.post(PrimProxy.opcodeMap.setSizeTo, { SIZE: size });
     }
 
-    setLayerTo(frontBack) {
-        this.post(PrimProxy.opcodeMap.setLayerTo, { FRONT_BACK: frontBack });
+    async setLayerTo(frontBack) {
+        await this.post(PrimProxy.opcodeMap.setLayerTo, { FRONT_BACK: frontBack });
     }
 
-    changeLayerBy(num) {
-        this.post(PrimProxy.opcodeMap.changeLayerBy, { NUM: num });
+    async changeLayerBy(num) {
+        await this.post(PrimProxy.opcodeMap.changeLayerBy, { NUM: num });
     }
 
     // as above, no tests for async functions
     async getSize() {
-        const size = PrimProxy.post(this.opcodeMap.getSize, {});
+        const size = await this.post(this.opcodeMap.getSize, {});
         return size;
     }
 
     async getCostume() {
-        const costume = await PrimProxy.post(this.opcodeMap.getCostume, {
+        const costume = await this.post(this.opcodeMap.getCostume, {
             NUMBER_NAME: "name",
         });
         return costume;
     }
 
     async getBackdrop() {
-        const backdrop = await PrimProxy.post(this.opcodeMap.getBackdrop, {
+        const backdrop = await this.post(this.opcodeMap.getBackdrop, {
             NUMBER_NAME: "name",
         });
         return backdrop;
     }
 
-    playSound(soundMenu) {
-        this.post(PrimProxy.opcodeMap.playSound, { SOUND_MENU: soundMenu });
+    async playSound(soundMenu) {
+        await this.post(PrimProxy.opcodeMap.playSound, { SOUND_MENU: soundMenu });
     }
 
-    playSoundUntilDone(soundMenu) {
-        this.post(PrimProxy.opcodeMap.playSoundUntilDone, { SOUND_MENU: soundMenu });
+    async playSoundUntilDone(soundMenu) {
+        await this.post(PrimProxy.opcodeMap.playSoundUntilDone, { SOUND_MENU: soundMenu });
     }
 
-    stopAllSounds() {
-        this.post(PrimProxy.opcodeMap.stopAllSounds, {});
+    async stopAllSounds() {
+        await this.post(PrimProxy.opcodeMap.stopAllSounds, {});
     }
 
-    setSoundEffectTo(effect, value) {
-        this.post(PrimProxy.opcodeMap.setSoundEffectTo, { EFFECT: effect, VALUE: value });
+    async setSoundEffectTo(effect, value) {
+        await this.post(PrimProxy.opcodeMap.setSoundEffectTo, { EFFECT: effect, VALUE: value });
     }
 
-    changeSoundEffectBy(effect, value) {
-        this.post(PrimProxy.opcodeMap.changeSoundEffectBy, { EFFECT: effect, VALUE: value });
+    async changeSoundEffectBy(effect, value) {
+        await this.post(PrimProxy.opcodeMap.changeSoundEffectBy, { EFFECT: effect, VALUE: value });
     }
 
-    clearSoundEffects() {
-        this.post(PrimProxy.opcodeMap.clearSoundEffects, {});
+    async clearSoundEffects() {
+        await this.post(PrimProxy.opcodeMap.clearSoundEffects, {});
     }
 
-    setVolumeTo(volume) {
-        this.post(PrimProxy.opcodeMap.setVolumeTo, { VOLUME: volume });
+    async setVolumeTo(volume) {
+        await this.post(PrimProxy.opcodeMap.setVolumeTo, { VOLUME: volume });
     }
 
-    changeVolumeBy(volume) {
-        this.post(PrimProxy.opcodeMap.changeVolumeBy, { VOLUME: volume });
+    async changeVolumeBy(volume) {
+        await this.post(PrimProxy.opcodeMap.changeVolumeBy, { VOLUME: volume });
     }
 
     async getVolume() {
-        const volume = PrimProxy.post(this.opcodeMap.getVolume, {});
+        const volume = await this.post(this.opcodeMap.getVolume, {});
         return volume;
     }
 
-    broadcast(messageName) {
-        this.post(PrimProxy.opcodeMap.broadcast, { BROADCAST_OPTION: { id: messageName, name: messageName } });
+    async broadcast(messageName) {
+        await this.post(PrimProxy.opcodeMap.broadcast, { BROADCAST_OPTION: { id: messageName, name: messageName } });
     }
 
     async broadcastAndWait(messageName) {

--- a/test/linker/expected/global-number-expected.py
+++ b/test/linker/expected/global-number-expected.py
@@ -2,5 +2,5 @@ globalName1 = 12.1
 async def thread_id_0(vm_proxy):
     global globalName1
     move = vm_proxy.move
-    move(10)
+    await move(10)
 

--- a/test/linker/expected/global-string-expected.py
+++ b/test/linker/expected/global-string-expected.py
@@ -2,5 +2,5 @@ globalName1 = 'value'
 async def thread_id_0(vm_proxy):
     global globalName1
     move = vm_proxy.move
-    move(10)
+    await move(10)
 

--- a/test/linker/expected/multiline-expected.py
+++ b/test/linker/expected/multiline-expected.py
@@ -1,6 +1,6 @@
 async def thread_id_0(vm_proxy):
     move = vm_proxy.move
     goTo = vm_proxy.goTo
-    goTo("target1")
-    move(10)
+    await goTo("target1")
+    await move(10)
 

--- a/test/linker/expected/multithread-expected.py
+++ b/test/linker/expected/multithread-expected.py
@@ -1,16 +1,16 @@
 async def thread_id_0(vm_proxy):
     move = vm_proxy.move
-    move(10)
+    await move(10)
 
 async def thread_id_1(vm_proxy):
     goToXY = vm_proxy.goToXY
-    goToXY(10, 10)
+    await goToXY(10, 10)
 
 async def thread_id_2(vm_proxy):
     goTo = vm_proxy.goTo
-    goTo("target2")
+    await goTo("target2")
 
 async def thread_id_3(vm_proxy):
     turnRight = vm_proxy.turnRight
-    turnRight(90)
+    await turnRight(90)
 

--- a/test/linker/expected/multithread-multievent-expected.py
+++ b/test/linker/expected/multithread-multievent-expected.py
@@ -1,16 +1,16 @@
 async def thread_id_0(vm_proxy):
     move = vm_proxy.move
-    move(10)
+    await move(10)
 
 async def thread_id_1(vm_proxy):
     goToXY = vm_proxy.goToXY
-    goToXY(10, 10)
+    await goToXY(10, 10)
 
 async def thread_id_2(vm_proxy):
     goTo = vm_proxy.goTo
-    goTo("target2")
+    await goTo("target2")
 
 async def thread_id_3(vm_proxy):
     turnRight = vm_proxy.turnRight
-    turnRight(90)
+    await turnRight(90)
 

--- a/test/linker/expected/simple-expected.py
+++ b/test/linker/expected/simple-expected.py
@@ -1,4 +1,4 @@
 async def thread_id_0(vm_proxy):
     move = vm_proxy.move
-    move(10)
+    await move(10)
 

--- a/test/linker/expected/while-loop-expected.py
+++ b/test/linker/expected/while-loop-expected.py
@@ -1,6 +1,6 @@
 async def thread_id_0(vm_proxy):
     move = vm_proxy.move
     while True:
-        move(10)
-        move(10)
+        await move(10)
+        await move(10)
 

--- a/test/linker/linker.test.mjs
+++ b/test/linker/linker.test.mjs
@@ -155,6 +155,7 @@ describe("Pyatch File Linker", () => {
             expect(threads).to.deep.equal({ event_whenflagclicked: ["id_0"] });
             expect(code).to.equal(expected);
         });
+
         it("No code, 1 thread", () => {
             const globalVariables = {};
 
@@ -165,6 +166,24 @@ describe("Pyatch File Linker", () => {
             };
 
             const file = path.join(__dirname, "expected", "no-code-expected.py");
+            const expected = fs.readFileSync(file, "utf8", (err, data) => data);
+
+            const [code, threads] = linker.generatePython(threadCode, globalVariables);
+
+            expect(threads).to.deep.equal({ event_whenflagclicked: ["id_0"] });
+            expect(code).to.equal(expected);
+        });
+
+        it("1 target, 1 line of code pre awaited, 1 thread", () => {
+            const globalVariables = {};
+
+            const threadCode = {
+                event_whenflagclicked: {
+                    id_0: "await move(10)",
+                },
+            };
+
+            const file = path.join(__dirname, "expected", "simple-expected.py");
             const expected = fs.readFileSync(file, "utf8", (err, data) => data);
 
             const [code, threads] = linker.generatePython(threadCode, globalVariables);


### PR DESCRIPTION
### Proposed Changes

Linker will add the `await` keyword before Patch Primitive function calls in python in order to ensure that the execution of python script is synchronous with the VM's execution of the requests.

### Reason for Changes

Notably, it was the root of the bug [BXC-76](https://linear.app/bxcoding/issue/BXC-76/infinite-while-loop-bug)

### Test Coverage

Added two linker tests
