### PR TITLE
feat: added support for event & option lists

### DIFF
--- a/src/blocks/scratch3_event.mjs
+++ b/src/blocks/scratch3_event.mjs
@@ -33,29 +33,37 @@ export default class Scratch3EventBlocks {
     getHats() {
         return {
             event_whenflagclicked: {
+                label: "When Flag Clicked",
                 restartExistingThreads: true,
             },
             event_whenkeypressed: {
+                label: "When Key Pressed",
                 restartExistingThreads: false,
             },
             event_whenthisspriteclicked: {
+                label: "When This Sprite Clicked",
                 restartExistingThreads: true,
             },
             event_whentouchingobject: {
+                label: "When Touching",
                 restartExistingThreads: false,
                 edgeActivated: true,
             },
             event_whenstageclicked: {
+                label: "When Stage Clicked",
                 restartExistingThreads: true,
             },
             event_whenbackdropswitchesto: {
+                label: "When Backdrop Switches To",
                 restartExistingThreads: true,
             },
             event_whengreaterthan: {
+                label: "When Greater Than",
                 restartExistingThreads: false,
                 edgeActivated: true,
             },
             event_whenbroadcastreceived: {
+                label: "When Broadcast Received",
                 restartExistingThreads: true,
             },
         };

--- a/src/engine/runtime.mjs
+++ b/src/engine/runtime.mjs
@@ -90,6 +90,13 @@ export default class Runtime extends EventEmitter {
         this._steppingInterval = null;
 
         /**
+         * Map to look up hat blocks' metadata.
+         * Keys are opcode for hat, values are metadata objects.
+         * @type {Object.<string, Object>}
+         */
+        this._hats = {};
+
+        /**
          * A dictionary of all threads running no the Patch vm. Dict keys
          * are thread id.
          * @type {Dictionary.<String, Thread>}
@@ -262,16 +269,16 @@ export default class Runtime extends EventEmitter {
                         }
                     }
                 }
-                /* Don't Need Hats Right Now (or ever?)
+
                 if (packageObject.getHats) {
                     const packageHats = packageObject.getHats();
+                    // eslint-disable-next-line no-restricted-syntax
                     for (const hatName in packageHats) {
                         if (packageHats.hasOwnProperty(hatName)) {
                             this._hats[hatName] = packageHats[hatName];
                         }
                     }
                 }
-                */
             }
         }
     }

--- a/src/io/keyboard.mjs
+++ b/src/io/keyboard.mjs
@@ -4,7 +4,7 @@ import Cast from '../util/cast.mjs';
  * Names used internally for keys used in scratch, also known as "scratch keys".
  * @enum {string}
  */
-const KEY_NAME = {
+export const KEY_NAME = {
     SPACE: 'space',
     LEFT: 'left arrow',
     UP: 'up arrow',

--- a/src/virtual-machine.mjs
+++ b/src/virtual-machine.mjs
@@ -11,6 +11,7 @@ import sb3 from "./serialization/sb3.mjs";
 import sb2 from "./serialization/sb2.mjs";
 
 import StringUtil from "./util/string-util.mjs";
+import { KEY_NAME } from "./io/keyboard.mjs";
 
 const RESERVED_NAMES = ["_mouse_", "_stage_", "_edge_", "_myself_", "_random_"];
 
@@ -436,6 +437,45 @@ export default class VirtualMachine extends EventEmitter {
         }
         // If the target cannot be found by id, return a rejected promise
         return Promise.reject();
+    }
+
+    getEventLabels() {
+        const hats = this.runtime._hats;
+        const eventLabels = {};
+        Object.keys(hats).forEach((hatId) => {
+            eventLabels[hatId] = hats[hatId].label;
+        });
+        return eventLabels;
+    }
+
+    getBackdropNames() {
+        return ["none"];
+    }
+
+    getSpriteNames() {
+        const targetNames = this.runtime.targets.map((target) => target.sprite.name);
+        return targetNames;
+    }
+
+    getKeyboardOptions() {
+        const characterKeys = Array.from(Array(26), (e, i) => String.fromCharCode(65 + i));
+        const scratchKeys = Object.keys(KEY_NAME).map((keyId) => keyId);
+
+        return characterKeys.concat(scratchKeys);
+    }
+
+    // There is 100% a better way to implement this
+    getEventOptionsMap(eventId) {
+        return {
+            event_whenflagclicked: null,
+            event_whenkeypressed: this.getKeyboardOptions(),
+            event_whenthisspriteclicked: null,
+            event_whentouchingobject: this.getSpriteNames(),
+            event_whenstageclicked: null,
+            event_whenbackdropswitchesto: this.getBackdropNames(),
+            event_whengreaterthan: null,
+            event_whenbroadcastreceived: "Free Input",
+        }[eventId];
     }
 
     /**

--- a/test/scratch_vm/add_sprite.test.mjs
+++ b/test/scratch_vm/add_sprite.test.mjs
@@ -15,12 +15,9 @@ const { expect } = chai;
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const PATH_TO_PYODIDE = path.join(__dirname, "../../node_modules/pyodide");
-const PATH_TO_WORKER = path.join(__dirname, "../../src/worker/pyodide-web.worker.mjs");
-
 describe("Add Sprite", () => {
     it("From Sprite3 File", async () => {
-        const vm = new VirtualMachine(PATH_TO_PYODIDE, PATH_TO_WORKER);
+        const vm = new VirtualMachine();
 
         vm.attachStorage(makeTestStorage());
 

--- a/test/scratch_vm/event_info.test.mjs
+++ b/test/scratch_vm/event_info.test.mjs
@@ -1,0 +1,52 @@
+import path from "path";
+import { fileURLToPath } from "url";
+
+import chai from "chai";
+import sinonChai from "sinon-chai";
+import VirtualMachine from "../../src/virtual-machine.mjs";
+
+import { readFileToBuffer } from "../fixtures/readProjectFile.mjs";
+
+import makeTestStorage from "../fixtures/make-test-storage.mjs";
+
+chai.use(sinonChai);
+const { expect } = chai;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe("Event Info", () => {
+    it("Get Event Labels", async () => {
+        const vm = new VirtualMachine();
+        const expected = {
+            event_whenflagclicked: "When Flag Clicked",
+            event_whenkeypressed: "When Key Pressed",
+            event_whenthisspriteclicked: "When This Sprite Clicked",
+            event_whentouchingobject: "When Touching",
+            event_whenstageclicked: "When Stage Clicked",
+            event_whenbackdropswitchesto: "When Backdrop Switches To",
+            event_whengreaterthan: "When Greater Than",
+            event_whenbroadcastreceived: "When Broadcast Received",
+        };
+
+        const result = vm.getEventLabels();
+
+        expect(result).to.eql(expected);
+    });
+
+    it("Get Sprite Names", async () => {
+        const vm = new VirtualMachine();
+        const expected = ["Sprite1", "Sprite2", "Sprite3"];
+
+        vm.attachStorage(makeTestStorage());
+
+        const sprite3Uri = path.resolve(__dirname, "../fixtures/cat.sprite3");
+        const sprite3 = readFileToBuffer(sprite3Uri);
+
+        await Promise.all([vm.addSprite(sprite3), vm.addSprite(sprite3), vm.addSprite(sprite3)]);
+
+        const result = vm.getSpriteNames();
+
+        expect(result).to.eql(expected);
+    });
+});


### PR DESCRIPTION
### Resolves

[BXC-125](https://linear.app/bxcoding/issue/BXC-125/select-thread-trigger-event-vm-support)

### Reason for Changes

To support the listing of possible events and options for those events, the VM API needed to be updated.

### Test Coverage

Added three tests to cover the non-trivial methods.
